### PR TITLE
Fix: syntax error in deploy.js blueprint

### DIFF
--- a/blueprints/lightning-deploy-config/files/config/deploy.js
+++ b/blueprints/lightning-deploy-config/files/config/deploy.js
@@ -61,6 +61,4 @@ module.exports = function(deployTarget) {
    *    });
    *
    */
-
-  });
 }


### PR DESCRIPTION
Deploy.js from the blueprint errored for me after inserting my s3 bucket key. Seems to be a leftover '})' in there.